### PR TITLE
switch chart to image by goreleaser

### DIFF
--- a/helm/opensoho/Chart.yaml
+++ b/helm/opensoho/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: opensoho
 description: A Helm chart for OpenSoho - OpenWrt management platform
 type: application
-version: 0.1.0
-appVersion: "1.0.0"
+version: 0.2.0
+appVersion: "v0.7.3"
 keywords:
   - opensoho
   - openwrt

--- a/helm/opensoho/templates/deployment.yaml
+++ b/helm/opensoho/templates/deployment.yaml
@@ -11,6 +11,8 @@ spec:
   selector:
     matchLabels:
       {{- include "opensoho.selectorLabels" . | nindent 6 }}
+  strategy:
+    type: Recreate
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -42,10 +44,11 @@ spec:
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
+          args: ["serve", "--http=0.0.0.0:8090"]
           {{- if .Values.healthCheck.enabled }}
           readinessProbe:
             httpGet:
-              path: /
+              path: /api/health
               port: http
             initialDelaySeconds: {{ .Values.healthCheck.initialDelaySeconds }}
             periodSeconds: {{ .Values.healthCheck.periodSeconds }}
@@ -56,7 +59,7 @@ spec:
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
-              path: /
+              path: /api/health
               port: http
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
@@ -66,13 +69,18 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          {{- if .Values.persistence.enabled }}
           volumeMounts:
+            - name: migrations
+              mountPath: /ko-app/pb_migrations
+          {{- if .Values.persistence.enabled }}
             - name: data
               mountPath: {{ .Values.persistence.mountPath }}
           {{- end }}
-      {{- if .Values.persistence.enabled }}
       volumes:
+        - name: migrations
+          emptyDir:
+            sizeLimit: 500Mi
+      {{- if .Values.persistence.enabled }}
         - name: data
           persistentVolumeClaim:
             claimName: {{ include "opensoho.fullname" . }}-data

--- a/helm/opensoho/values.yaml
+++ b/helm/opensoho/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: opensoho
+  repository: ghcr.io/opensoho/opensoho
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
@@ -32,7 +32,7 @@ securityContext:
   capabilities:
     drop:
     - ALL
-  readOnlyRootFilesystem: false
+  readOnlyRootFilesystem: true
   runAsNonRoot: true
   runAsUser: 1001
 
@@ -90,7 +90,7 @@ persistence:
   accessMode: ReadWriteOnce
   size: 10Gi
   # Mount path for persistent data
-  mountPath: /app/pb_data
+  mountPath: /ko-app/pb_data
 
 # Health checks
 healthCheck:


### PR DESCRIPTION
- switch chart to image by goreleaser
- mount emptyDir for migrations
- mount image readonly
~- use statefulset, as we want to stop the old pod before starting the new one and support a single replica only~
- use recreate deployment strategy, as we want to stop the old pod before starting the new one and support a single replica only
- switch probes to health endpoint