### PR TITLE
DRAFT: add build for ramips/realtek target, missing mips support in modernc.…

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,8 +22,11 @@ builds:
       - amd64
       - arm64
       - arm
+      - mipsle
     goarm:
       - 7
+    gomips:
+      - softfloat
 release:
   draft: true
 


### PR DESCRIPTION
…org/sqlite

In theory that's all it takes to build images to run an ramips routers and realtek switches (e.g. with external storage on USB for the database)

But mips is not yet supported... A checklist to add a new target to sqlite is in https://gitlab.com/cznic/sqlite/-/issues/210#note_2536714995