### PR TITLE
Fix broken Home Assistant doc link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ This view shows all wifi clients that are still connected within the previous 30
 
 ### Home Assistant integration
 
-OpenSOHO monitoring can be integrated with Home Assistant. [(More info)](doc/hass.md)
+OpenSOHO monitoring can be integrated with Home Assistant. [(More info)](https://opensoho.github.io/docs/home-assistant/)
 This REST API is designed for use with Home Assistant, but can also be integrated with other tools.
 
 ## Troubleshooting


### PR DESCRIPTION
The link to the Home Assistant integration (doc/hass.md) pointed to a non-existent file. Fixed to point to the correct documentation page: https://opensoho.github.io/docs/home-assistant/