### PR TITLE
feat: add startupProbe to Helm Chart

### DIFF
--- a/helm/opensoho/Chart.yaml
+++ b/helm/opensoho/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: opensoho
 description: A Helm chart for OpenSoho - OpenWrt management platform
 type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: "v0.15.0"
 keywords:
   - opensoho

--- a/helm/opensoho/README.md
+++ b/helm/opensoho/README.md
@@ -116,6 +116,7 @@ it manually only after taking a backup.
 | --------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ------- |
 | `healthCheck.enabled`       | Enable readiness probe                                                                                                          | `true`  |
 | `livenessProbe.enabled`     | Enable liveness probe                                                                                                           | `true`  |
+| `startupProbe.enabled`      | Enable startup probe                                                                                                            | `true`  |
 
 ## Configuration and installation details
 

--- a/helm/opensoho/templates/deployment.yaml
+++ b/helm/opensoho/templates/deployment.yaml
@@ -63,7 +63,6 @@ spec:
             httpGet:
               path: /api/health
               port: http
-            initialDelaySeconds: {{ .Values.healthCheck.initialDelaySeconds }}
             periodSeconds: {{ .Values.healthCheck.periodSeconds }}
             timeoutSeconds: {{ .Values.healthCheck.timeoutSeconds }}
             failureThreshold: {{ .Values.healthCheck.failureThreshold }}
@@ -74,11 +73,20 @@ spec:
             httpGet:
               path: /api/health
               port: http
-            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
             successThreshold: {{ .Values.livenessProbe.successThreshold }}
+          {{- end }}
+          {{- if .Values.startupProbe.enabled }}
+          startupProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+            successThreshold: {{ .Values.startupProbe.successThreshold }}
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/helm/opensoho/values.yaml
+++ b/helm/opensoho/values.yaml
@@ -94,20 +94,27 @@ persistence:
   # Keep the PocketBase database when the Helm release is uninstalled.
   resourcePolicyKeep: true
 
-# Health checks
+# readinessProbe, should traffic go to this replica?
 healthCheck:
   enabled: true
-  initialDelaySeconds: 30
   periodSeconds: 10
   timeoutSeconds: 5
   failureThreshold: 3
   successThreshold: 1
 
-# Liveness probe
+# Liveness probe, should we kill this replica?
 livenessProbe:
   enabled: true
-  initialDelaySeconds: 30
   periodSeconds: 10
   timeoutSeconds: 5
   failureThreshold: 3
+  successThreshold: 1
+
+# Startup probe, is this replica ready for service?
+startupProbe:
+  enabled: true
+  periodSeconds: 10
+  timeoutSeconds: 5
+  # 30 * 10 => 5 minutes to start up, before giving up
+  failureThreshold: 30
   successThreshold: 1


### PR DESCRIPTION
the new snapshot took to long to come up and was killed

so it was a good time to switch from old school initial delay to a proper startup probe