### PR TITLE
Fix possible fix(deps): 16 vulnerable dependencies in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,14 +44,14 @@ require (
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/spf13/cobra v1.10.2 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
-	golang.org/x/crypto v0.48.0 // indirect
+	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/exp v0.0.0-20260112195511-716be5621a96 // indirect
-	golang.org/x/image v0.36.0 // indirect
-	golang.org/x/net v0.50.0 // indirect
+	golang.org/x/image v0.43.0 // indirect
+	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/oauth2 v0.35.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
-	golang.org/x/text v0.34.0 // indirect
+	golang.org/x/text v0.39.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	modernc.org/libc v1.67.6 // indirect
 	modernc.org/mathutil v1.7.1 // indirect


### PR DESCRIPTION
Proposing a fix for something flagged in `go.mod`. It is around line 1.

The project depends on golang.org/x/net v0.50.0, which contains a flaw (CVE-2026-25681) that allows malicious HTML to be parsed and later rendered, leading to DOM‑based XSS. An attacker can inject payloads that survive any pre‑render sanitisation, potentially compromising user data and session integrity. The vulnerability is rated HIGH due to its impact on confidentiality, integrity, and availability of the application. Updating to the fixed version (>= v0.55.0) eliminates the vulnerable parsing code.

Updates indirect dependencies to versions that address known CVEs, eliminating high-severity vulnerabilities.

For reference: rule `CVE-2026-25681`. Rated high.

I may well be missing context here — if the current code is deliberate, feel free to close this.

---
*Found with automated scanning ([RedGem](https://code.redgem.net)) and reviewed before opening. If it is not useful, closing it is completely fine.*
